### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,37 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-01-19
+
+- Added easy selection of the UiConfigs.asset file. Just go to Tools > Select UiConfigs.asset. If the UiConfigs.asset does not exist, it will create a new one in the Assets folder
+- Added the protected Close() method to directly allow to close the UiPresenter from the UiPresenter object file without needing to call the UiService. Also now is possible to close an Ui in the service by referencing the object directly without needing to reference the object type by calling CloseUi<T>(T presenter)
+- Now the UnloadUi & UnloadUiSet properly unloads the ui from memory and removes it from the service
+- Added RemoveUi & RemoveUiPresentersFromSet to allow the ui to be removed from the service without being unloaded from memory
+- Improved documentation
+
+**Changed**
+- Now the Refresh method on the UiPresenter is public and can be called from any object that has asset to it. The UiService will not call this method anymore if trying to Open the same UiPresenter twice without closing
+- In the UiService, IsUiLoaded changed to HasUiPresenter
+- In the UiService IsAllUiLoadedInSet changed to HasAllUiPresentersInSet
+- Unified AddUi methods
+
+**Fixed**:
+- Fixed bug that sometimes don't save the UiConfigs state correctly
+
 ## [0.1.3] - 2020-01-09
 
-- Fixed bug that sometimes don't save the UiConfigs state correctly
+**Fixed**:
+- Bug that sometimes was not save+ing the UiConfigs state correctly
 
 ## [0.1.2] - 2020-01-09
 
-- Fixed compile errors
+**Fixed**:
+- Compiler Errors
 
 ## [0.1.1] - 2020-01-09
 
-- Fixed the state of a the UiPresenter when loaded. Now the UiPresenters are always disabled when loaded
+**Fixed**:
+- The state of a the UiPresenter when loaded. Now the UiPresenters are always disabled when loaded
 
 ## [0.1.0] - 2020-01-05
 

--- a/Editor/UiConfigsEditor.cs
+++ b/Editor/UiConfigsEditor.cs
@@ -12,6 +12,31 @@ using UnityEngine;
 namespace GameLoversEditor.UiService
 {
 	/// <summary>
+	/// Helps selecting the <see cref="UiConfigs"/> asset file in the Editor
+	/// </summary>
+	public static class UiConfigsSelect
+	{
+		
+		[MenuItem("Tools/Select UiConfigs.asset")]
+		private static void SelectUiConfigs()
+		{
+			var assets = AssetDatabase.FindAssets($"t:{nameof(UiConfigs)}");
+			var scriptableObject = assets.Length > 0 ? 
+				AssetDatabase.LoadAssetAtPath<UiConfigs>(AssetDatabase.GUIDToAssetPath(assets[0])) :
+				ScriptableObject.CreateInstance<UiConfigs>();
+
+			if (assets.Length == 0)
+			{
+				AssetDatabase.CreateAsset(scriptableObject, $"Assets/{nameof(UiConfigs)}.asset");
+				AssetDatabase.SaveAssets();
+				AssetDatabase.Refresh();
+			}
+
+			Selection.activeObject = scriptableObject;
+		}
+	}
+	
+	/// <summary>
 	/// Improves the inspector visualization for the <see cref="UiConfigs"/> scriptable object
 	/// </summary>
 	/// <remarks>

--- a/Runtime/UiPresenter.cs
+++ b/Runtime/UiPresenter.cs
@@ -10,32 +10,51 @@ namespace GameLovers.UiService
 	/// </summary>
 	public abstract class UiPresenter : MonoBehaviour
 	{
+		private IUiService _uiService;
+		
 		/// <summary>
 		/// Sets the UI <paramref name="data"/>
 		/// </summary>
 		public virtual void SetData<T>(T data) where T : struct {}
+
+		/// <summary>
+		/// Refreshes this opened UI
+		/// </summary>
+		public virtual void Refresh() {}
 		
-		internal void Refresh()
+		/// <summary>
+		/// Allows the ui presenter implementation to have extra behaviour when it is opened
+		/// </summary>
+		protected virtual void OnOpened() {}
+
+		/// <summary>
+		/// Allows the ui presenter implementation to have extra behaviour when it is closed
+		/// </summary>
+		protected virtual void OnClosed() {}
+
+		/// <summary>
+		/// Allows the ui presenter implementation to directly close the ui presenter without needing to call the service directly
+		/// </summary>
+		protected void Close()
 		{
-			OnRefresh();
+			_uiService.CloseUi(this);
 		}
 
-		internal void Open()
+		internal void Init(IUiService uiService)
+		{
+			_uiService = uiService;
+		}
+
+		internal void InternalOpen()
 		{
 			gameObject.SetActive(true);
 			OnOpened();
 		}
 
-		internal void Close()
+		internal void InternalClose()
 		{
 			gameObject.SetActive(false);
 			OnClosed();
 		}
-
-		protected virtual void OnRefresh() {}
-		
-		protected virtual void OnOpened() {}
-
-		protected virtual void OnClosed() {}
 	}
 }

--- a/Runtime/UiService.cs
+++ b/Runtime/UiService.cs
@@ -20,35 +20,56 @@ namespace GameLovers.UiService
 		/// <summary>
 		/// Adds the given UI <paramref name="config"/> to the service
 		/// </summary>
+		/// <exception cref="ArgumentException">
+		/// Thrown if the service already contains the given <paramref name="config"/>
+		/// </exception>
 		void AddUiConfig(UiConfig config);
 		
 		/// <summary>
-		/// Adds the given <paramref name="ui"/> to the service and to be included inside the given <paramref name="layer"/>
+		/// Adds the given <paramref name="uiPresenter"/> to the service and to be included inside the given <paramref name="layer"/>
 		/// </summary>
 		/// <exception cref="NullReferenceException">
-		/// Thrown if the given <paramref name="ui"/> is null
+		/// Thrown if the given <paramref name="uiPresenter"/> is null
 		/// </exception>
 		/// <exception cref="ArgumentException">
-		/// Thrown if the service already contains the given <paramref name="ui"/>
+		/// Thrown if the service already contains the given <paramref name="uiPresenter"/>
 		/// </exception>
-		void AddUi<T>(int layer, T ui) where T : UiPresenter;
+		void AddUi<T>(T uiPresenter, int layer) where T : UiPresenter;
 		
-		///<inheritdoc cref="AddUi{T}(int,T)"/>
-		/// <exception cref="InvalidCastException">
-		/// Thrown if the given <paramref name="type"/> is not a sub class of <seealso cref="UiPresenter"/>
+		/// <summary>
+		/// Removes and returns the UI of the given type <typeparamref name="T"/> without unloading it from the service
+		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiPresenter"/> of the given type <typeparamref name="T"/>
 		/// </exception>
-		void AddUi(int layer, UiPresenter ui, Type type);
+		T RemoveUi<T>() where T : UiPresenter;
+
+		/// <summary>
+		/// Removes and returns the UI of the given <paramref name="type"/> without unloading it from the service
+		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiPresenter"/> of the given <paramref name="type"/>
+		/// </exception>
+		UiPresenter RemoveUi(Type type);
 		
 		/// <summary>
 		/// Loads an UI asynchronously with the given <typeparamref name="T"/>
 		/// This method can be controlled in an async method and returns the UI loaded
 		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain a <see cref="UiConfig"/> of the given type <typeparamref name="T"/>.
+		/// You need to call <seealso cref="AddUiConfig"/> or <seealso cref="AddUi{T}"/> or initialize the service first
+		/// </exception>
 		Task<T> LoadUiAsync<T>() where T : UiPresenter;
 		
 		/// <summary>
 		/// Loads an UI asynchronously with the given <paramref name="type"/>
 		/// This method can be controlled in an async method and returns the UI loaded
 		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain a <see cref="UiConfig"/> of the given <paramref name="type"/>
+		/// You need to call <seealso cref="AddUiConfig"/> or <seealso cref="AddUi{T}"/> or initialize the service first
+		/// </exception>
 		Task<UiPresenter> LoadUiAsync(Type type);
 		
 		/// <summary>
@@ -57,7 +78,7 @@ namespace GameLovers.UiService
 		/// <exception cref="KeyNotFoundException">
 		/// Thrown if the service does NOT contain an <see cref="UiPresenter"/> of the given type <typeparamref name="T"/>
 		/// </exception>
-		T UnloadUi<T>() where T : UiPresenter;
+		void UnloadUi<T>() where T : UiPresenter;
 		
 		/// <summary>
 		/// Unloads the UI of the given <paramref name="type"/>
@@ -65,17 +86,17 @@ namespace GameLovers.UiService
 		/// <exception cref="KeyNotFoundException">
 		/// Thrown if the service does NOT contain an <see cref="UiPresenter"/> of the given <paramref name="type"/>
 		/// </exception>
-		UiPresenter UnloadUi(Type type);
+		void UnloadUi(Type type);
 		
 		/// <summary>
-		/// Checks if the <seealso cref="UiPresenter"/> of the given <typeparamref name="T"/> is loaded or not
+		/// Checks if the service contains <seealso cref="UiPresenter"/> of the given <typeparamref name="T"/>
 		/// </summary>
-		bool IsUiLoaded<T>() where T : UiPresenter;
+		bool HasUiPresenter<T>() where T : UiPresenter;
 		
 		/// <summary>
-		/// Checks if the <seealso cref="UiPresenter"/> of the given <paramref name="type"/> is loaded or not 
+		/// Checks if the service contains <seealso cref="UiPresenter"/> of the given <paramref name="type"/> is loaded or not 
 		/// </summary>
-		bool IsUiLoaded(Type type);
+		bool HasUiPresenter(Type type);
 		
 		/// <summary>
 		/// Requests the UI of given type <typeparamref name="T"/>
@@ -96,7 +117,6 @@ namespace GameLovers.UiService
 		/// <summary>
 		/// Requests the list all the visible UIs' <seealso cref="Type"/> on the screen
 		/// </summary>
-		/// <returns></returns>
 		List<Type> GetAllVisibleUi();
 
 		/// <summary>
@@ -144,6 +164,17 @@ namespace GameLovers.UiService
 		UiPresenter CloseUi(Type type);
 
 		/// <summary>
+		/// Closes and returns the same given <paramref name="uiPresenter"/>
+		/// </summary>
+		/// <exception cref="NullReferenceException">
+		/// Thrown if the given <paramref name="uiPresenter"/> is null
+		/// </exception>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain the given <paramref name="uiPresenter"/>
+		/// </exception>
+		T CloseUi<T>(T uiPresenter) where T : UiPresenter;
+
+		/// <summary>
 		/// Closes all the visible <seealso cref="UiPresenter"/>
 		/// </summary>
 		void CloseAllUi();
@@ -169,13 +200,35 @@ namespace GameLovers.UiService
 		/// Thrown if the service already contains the given <paramref name="uiSet"/>
 		/// </exception>
 		void AddUiSet(UiSetConfig uiSet);
+
+		/// <summary>
+		/// Removes and returns all the <see cref="UiPresenter"/> from given <paramref name="setId "/> that are still present in the service
+		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
+		/// </exception>
+		List<UiPresenter> RemoveUiPresentersFromSet(int setId);
 		
 		/// <summary>
-		/// Loads asynchronously all the <see cref="UiPresenter"/> from given <paramref name="uiSetId "/> and have not yet been loaded.
+		/// Loads asynchronously all the <see cref="UiPresenter"/> from given <paramref name="setId "/> and have not yet been loaded.
 		/// This method can be controlled in an async method and returns every UI when completes loaded.
 		/// This method can be controlled in a foreach loop and it will return the UIs in a first-load-first-return scheme 
 		/// </summary>
-		Task<Task<UiPresenter>>[] LoadUiSetAsync(int uiSetId);
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
+		/// </exception>
+		Task<Task<UiPresenter>>[] LoadUiSetAsync(int setId);
+
+		/// <summary>
+		/// Unloads all the <see cref="UiPresenter"/> from given <paramref name="setId "/> that are still present in the service
+		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
+		/// </exception>
+		void UnloadUiSet(int setId);
 
 		/// <summary>
 		/// Checks if the service contains or not the <seealso cref="UiSetConfig"/> of the given <paramref name="setId"/>
@@ -183,18 +236,20 @@ namespace GameLovers.UiService
 		bool HasUiSet(int setId);
 
 		/// <summary>
-		/// Checks if all the <seealso cref="UiPresenter"/> belonging in the given <paramref name="setId"/> is loaded or not
+		/// Checks if the service containers all the <seealso cref="UiPresenter"/> belonging in the given <paramref name="setId"/>
 		/// </summary>
 		/// <exception cref="KeyNotFoundException">
-		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> of the given <paramref name="setId"/>
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
 		/// </exception>
-		bool IsAllUiLoadedInSet(int setId);
+		bool HasAllUiPresentersInSet(int setId);
 		
 		/// <summary>
 		/// Requests the <seealso cref="UiSetConfig"/> of given type <paramref name="setId"/>
 		/// </summary>
 		/// <exception cref="KeyNotFoundException">
-		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> of the given <paramref name="setId"/>
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
 		/// </exception>
 		UiSetConfig GetUiSet(int setId);
 		
@@ -204,7 +259,8 @@ namespace GameLovers.UiService
 		/// that are not part of the given <paramref name="setId"/>
 		/// </summary>
 		/// <exception cref="KeyNotFoundException">
-		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> of with the given <paramref name="setId"/>
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
 		/// </exception>
 		void OpenUiSet(int setId, bool closeVisibleUi);
 		
@@ -212,7 +268,8 @@ namespace GameLovers.UiService
 		/// Closes all the <seealso cref="UiPresenter"/> that are part of the given <paramref name="setId"/>
 		/// </summary>
 		/// <exception cref="KeyNotFoundException">
-		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> of with the given <paramref name="setId"/>
+		/// Thrown if the service does NOT contain an <see cref="UiSetConfig"/> with the given <paramref name="setId"/>.
+		/// You need to add it first by calling <seealso cref="AddUiSet"/>
 		/// </exception>
 		void CloseUiSet(int setId);
 	}
@@ -229,6 +286,9 @@ namespace GameLovers.UiService
 		/// <summary>
 		/// Initialize the service with the proper <paramref name="configs"/>
 		/// </summary>
+		/// <exception cref="ArgumentException">
+		/// Thrown if any of the <see cref="UiConfig"/> in the given <paramref name="configs"/> is duplicated
+		/// </exception>
 		public void Init(UiConfigs configs)
 		{
 			var uiConfigs = configs.Configs;
@@ -257,34 +317,25 @@ namespace GameLovers.UiService
 		}
 
 		/// <inheritdoc />
-		public void AddUi<T>(int layer, T ui) where T : UiPresenter
+		public void AddUi<T>(T uiPresenter, int layer) where T : UiPresenter
 		{
-			AddUi(layer, ui, typeof(T));
-		}
-
-		/// <inheritdoc />
-		public void AddUi(int layer, UiPresenter ui, Type type)
-		{
-			if (ui == null)
+			var type = uiPresenter.GetType().UnderlyingSystemType;
+			
+			if (uiPresenter == null)
 			{
 				throw new NullReferenceException($"The Ui {type} cannot be null");
 			}
 			
-			if (IsUiLoaded(type))
+			if (HasUiPresenter(type))
 			{
 				throw new ArgumentException($"The Ui {type} was already added");
-			}
-
-			if (!typeof(UiPresenter).IsAssignableFrom(type))
-			{
-				throw new InvalidCastException($"The Ui {type} is not of a {typeof(UiPresenter)} type");
 			}
 			
 			var reference = new UiReference
 			{
 				UiType = type,
 				Layer = layer,
-				Presenter = ui
+				Presenter = uiPresenter
 			};
 			
 			for(int i = _layers.Count; i <= layer; i++)
@@ -300,7 +351,28 @@ namespace GameLovers.UiService
 			}
 			
 			_uiViews.Add(reference.UiType, reference);
-			ui.transform.SetParent(_layers[layer].transform);
+			uiPresenter.transform.SetParent(_layers[layer].transform);
+			uiPresenter.Init(this);
+		}
+
+		/// <inheritdoc />
+		public T RemoveUi<T>() where T : UiPresenter
+		{
+			return RemoveUi(typeof(T)) as T;
+		}
+
+		/// <inheritdoc />
+		public UiPresenter RemoveUi(Type type)
+		{
+			if (!_uiViews.TryGetValue(type, out UiReference reference))
+			{
+				throw new KeyNotFoundException($"The Ui {type} is not present to be removed");
+			}
+			
+			_uiViews.Remove(type);
+			_visibleUiList.Remove(type);
+
+			return reference.Presenter;
 		}
 
 		/// <inheritdoc />
@@ -319,7 +391,7 @@ namespace GameLovers.UiService
 				throw new KeyNotFoundException($"The UiConfig of type {type} was not added to the service. Call {nameof(AddUiConfig)} first");
 			}
 			
-			var operation = Addressables.LoadAssetAsync<GameObject>(config.AddressableAddress);
+			var operation = Addressables.InstantiateAsync(config.AddressableAddress);
 
 			await operation.Task;
 
@@ -328,11 +400,10 @@ namespace GameLovers.UiService
 				throw operation.OperationException;
 			}
 			
-			// ReSharper disable once AccessToStaticMemberViaDerivedType
-			var uiPresenter = GameObject.Instantiate(operation.Result).GetComponent<UiPresenter>();
+			var uiPresenter = operation.Result.GetComponent<UiPresenter>();
 
-			AddUi(config.Layer, uiPresenter, config.UiType);
-			Addressables.Release(operation);
+			AddUi(uiPresenter, config.Layer);
+			Addressables.ReleaseInstance(uiPresenter.gameObject);
 			
 			uiPresenter.gameObject.SetActive(false);
 
@@ -340,34 +411,25 @@ namespace GameLovers.UiService
 		}
 
 		/// <inheritdoc />
-		public T UnloadUi<T>() where T : UiPresenter
+		public void UnloadUi<T>() where T : UiPresenter
 		{
-			return UnloadUi(typeof(T)) as T;
+			UnloadUi(typeof(T));
 		}
 
 		/// <inheritdoc />
-		public UiPresenter UnloadUi(Type type)
+		public void UnloadUi(Type type)
 		{
-			if (!_uiViews.TryGetValue(type, out UiReference reference))
-			{
-				throw new KeyNotFoundException($"The Ui {type} is not present to be removed");
-			}
-			
-			UiPresenter presenter = reference.Presenter;
-
-			_uiViews.Remove(type);
-
-			return presenter;
+			Object.Destroy(RemoveUi(type).gameObject);
 		}
 
 		/// <inheritdoc />
-		public bool IsUiLoaded<T>() where T : UiPresenter
+		public bool HasUiPresenter<T>() where T : UiPresenter
 		{
-			return IsUiLoaded(typeof(T));
+			return HasUiPresenter(typeof(T));
 		}
 
 		/// <inheritdoc />
-		public bool IsUiLoaded(Type type)
+		public bool HasUiPresenter(Type type)
 		{
 			return _uiViews.ContainsKey(type);
 		}
@@ -403,12 +465,12 @@ namespace GameLovers.UiService
 			
 			if (!_visibleUiList.Contains(type))
 			{
-				ui.Open();
+				ui.InternalOpen();
 				_visibleUiList.Add(type);
 			}
 			else
 			{
-				ui.Refresh();
+				Debug.LogWarning($"Is trying to open the {type.Name} ui but is already open");
 			}
 			
 			return ui;
@@ -442,10 +504,27 @@ namespace GameLovers.UiService
 			if (_visibleUiList.Contains(type))
 			{
 				_visibleUiList.Remove(type);
-				ui.Close();
+				ui.InternalClose();
+			}
+			else
+			{
+				Debug.LogWarning($"Is trying to close the {type.Name} ui but is not open");
 			}
 
 			return ui;
+		}
+
+		/// <inheritdoc />
+		public T CloseUi<T>(T uiPresenter) where T : UiPresenter
+		{
+			if (uiPresenter == null)
+			{
+				throw new NullReferenceException($"The Ui {uiPresenter.GetType().UnderlyingSystemType} cannot be null");
+			}
+			
+			CloseUi(uiPresenter.GetType().UnderlyingSystemType);
+
+			return uiPresenter;
 		}
 
 		/// <inheritdoc />
@@ -453,7 +532,7 @@ namespace GameLovers.UiService
 		{
 			for (int i = 0; i < _visibleUiList.Count; i++)
 			{
-				GetUi(_visibleUiList[i]).Close();
+				GetUi(_visibleUiList[i]).InternalClose();
 				_visibleUiList.Remove(_visibleUiList[i]);
 			}
 			
@@ -484,32 +563,51 @@ namespace GameLovers.UiService
 				var reference = GetReference(_visibleUiList[i]);
 				if (reference.Layer == layer)
 				{
-					reference.Presenter.Close();
+					reference.Presenter.InternalClose();
 					_visibleUiList.Remove(reference.UiType);
 				}
 			}
 		}
 
 		/// <inheritdoc />
-		public void AddUiSet(UiSetConfig set)
+		public void AddUiSet(UiSetConfig uiSet)
 		{
-			if (_uiSets.ContainsKey(set.SetId))
+			if (_uiSets.ContainsKey(uiSet.SetId))
 			{
-				throw new ArgumentException($"The Ui Configuration with the id {set.SetId.ToString()} was already added");
+				throw new ArgumentException($"The Ui Configuration with the id {uiSet.SetId.ToString()} was already added");
 			}
 			
-			_uiSets.Add(set.SetId, set);
+			_uiSets.Add(uiSet.SetId, uiSet);
 		}
 
 		/// <inheritdoc />
-		public Task<Task<UiPresenter>>[] LoadUiSetAsync(int uiSetId)
+		public List<UiPresenter> RemoveUiPresentersFromSet(int setId)
 		{
-			var set = GetUiSet(uiSetId);
+			var set = GetUiSet(setId);
+			var list = new List<UiPresenter>();
+
+			for (int i = 0; i < set.UiConfigsType.Count; i++)
+			{
+				if (!HasUiPresenter(set.UiConfigsType[i]))
+				{
+					continue;
+				}
+				
+				list.Add(RemoveUi(set.UiConfigsType[i]));
+			}
+
+			return list;
+		}
+
+		/// <inheritdoc />
+		public Task<Task<UiPresenter>>[] LoadUiSetAsync(int setId)
+		{
+			var set = GetUiSet(setId);
 			var uiTasks = new List<Task<UiPresenter>>();
 
 			for (int i = 0; i < set.UiConfigsType.Count; i++)
 			{
-				if (IsUiLoaded(set.UiConfigsType[i]))
+				if (HasUiPresenter(set.UiConfigsType[i]))
 				{
 					continue;
 				}
@@ -518,7 +616,20 @@ namespace GameLovers.UiService
 			}
 
 			return LoaderUtil.Interleaved(uiTasks);
+		}
 
+		/// <inheritdoc />
+		public void UnloadUiSet(int setId)
+		{
+			var set = GetUiSet(setId);
+
+			for (var i = 0; i < set.UiConfigsType.Count; i++)
+			{
+				if (HasUiPresenter(set.UiConfigsType[i]))
+				{
+					UnloadUi(set.UiConfigsType[i]);
+				}
+			}
 		}
 
 		/// <inheritdoc />
@@ -528,13 +639,13 @@ namespace GameLovers.UiService
 		}
 
 		/// <inheritdoc />
-		public bool IsAllUiLoadedInSet(int setId)
+		public bool HasAllUiPresentersInSet(int setId)
 		{
 			var set = GetUiSet(setId);
 
 			for (var i = 0; i < set.UiConfigsType.Count; i++)
 			{
-				if (!IsUiLoaded(set.UiConfigsType[i]))
+				if (!HasUiPresenter(set.UiConfigsType[i]))
 				{
 					return false;
 				}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "com.gamelovers.uiservice",
   "displayName": "UiService",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "unity": "2019.3",
   "description": "This package provides a service to help manage an Unity's, game UI.\nIt allows to open, close, load, unload and request any Ui Configured in the game.\nThe package provides a Ui Set that allows to group a set of Ui Presenters to help load, open and close multiple Uis at the same time.\n\nTo help configure the game's UI you need to create a UiConfigs Scriptable object by:\n- Right Click on the Project View > Create > ScriptableObjects > Configs > UiConfigs",
   "dependencies": {
-    "com.unity.addressables": "1.5.0"
+    "com.unity.addressables": "1.5.1"
   },
   "type": "library",
   "hideInEditor": false


### PR DESCRIPTION

- Added easy selection of the UiConfigs.asset file. Just go to Tools > Select UiConfigs.asset. If the UiConfigs.asset does not exist, it will create a new one in the Assets folder
- Added the protected Close() method to directly allow to close the UiPresenter from the UiPresenter object file without needing to call the UiService. Also now is possible to close an Ui in the service by referencing the object directly without needing to reference the object type by calling CloseUi<T>(T presenter)
- Now the UnloadUi & UnloadUiSet properly unloads the ui from memory and removes it from the service
- Added RemoveUi & RemoveUiPresentersFromSet to allow the ui to be removed from the service without being unloaded from memory
- Improved documentation

**Changed**
- Now the Refresh method on the UiPresenter is public and can be called from any object that has asset to it. The UiService will not call this method anymore if trying to Open the same UiPresenter twice without closing
- In the UiService, IsUiLoaded changed to HasUiPresenter
- In the UiService IsAllUiLoadedInSet changed to HasAllUiPresentersInSet
- Unified AddUi methods

**Fixed**:
- Fixed bug that sometimes don't save the UiConfigs state correctly