### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+
+## [0.9.0] - 2024-11-01
+
+- Added *GetUi<T>* method to the *IUiService*. It requests the *UiPresenter* by directly using generic T
+- Added *IsVisible<T>* method to the *IUiService*. It requests the visibility state of *UiPresenter*
+- Added IReadOnlyList property *VisiblePresenters* to the *IUiService* to allow external entities to access the list of visible *UiPresenter*
+
+***Changed**:
+- Removed *GetAllVisibleUi()* method. Use *IsVisible<T>* method instead
+
 ## [0.8.0] - 2024-10-29
 
 - Added new *PresenterDelayerBase*, *AnimationDelayer* and *TimeDelayer* to support presenters that open/close with a delay

--- a/Runtime/IUiService.cs
+++ b/Runtime/IUiService.cs
@@ -17,6 +17,11 @@ namespace GameLovers.UiService
 		/// Gets a read-only dictionary of the Presenters currently Loaded in memory by the UI service.
 		/// </summary>
 		IReadOnlyDictionary<Type, UiPresenter> LoadedPresenters { get; }
+		
+		/// <summary>
+		/// Gets a read-only list of the Presenters currently currently visible and were opened by the UI service.
+		/// </summary>
+		IReadOnlyList<Type> VisiblePresenters { get; }
 
 		/// <summary>
 		/// Gets a read-only dictionary of the layers used by the UI service.
@@ -27,6 +32,23 @@ namespace GameLovers.UiService
 		/// Gets a read-only dictionary of the containers of UI, called 'Ui Set' maintained by the UI service.
 		/// </summary>
 		IReadOnlyDictionary<int, UiSetConfig> UiSets { get; }
+
+		/// <summary>
+		/// Requests the UI of given type <typeparamref name="T"/>
+		/// </summary>
+		/// <exception cref="KeyNotFoundException">
+		/// Thrown if the service does NOT contain an <see cref="UiPresenter"/> of the given <typeparamref name="T"/>
+		/// </exception>
+		/// <typeparam name="T">The type of UI presenter requested.</typeparam>
+		/// <returns>The UI of type <typeparamref name="T"/> requested</returns>
+		T GetUi<T>() where T : UiPresenter;
+
+		/// <summary>
+		/// Requests the visible state of the given UI type <typeparamref name="T"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of UI presenter to check if is visible or not.</typeparam>
+		/// <returns>True if the UI is visble, false otherwise</returns>
+		bool IsVisible<T>() where T : UiPresenter;
 
 		/// <summary>
 		/// Adds a UI configuration to the service.
@@ -140,12 +162,6 @@ namespace GameLovers.UiService
 		/// <param name="setId">The ID of the UI set to unload from.</param>
 		/// <exception cref="KeyNotFoundException">Thrown if the service does not contain a UI set with the specified ID.</exception>
 		void UnloadUiSet(int setId);
-
-		/// <summary>
-		/// Gets a list of all visible UI presenters.
-		/// </summary>
-		/// <returns>A list of types of visible UI presenters.</returns>
-		List<Type> GetAllVisibleUi();
 
 		/// <summary>
 		/// Opens a UI presenter asynchronously, loading its assets if necessary.

--- a/Runtime/UiService.cs
+++ b/Runtime/UiService.cs
@@ -19,6 +19,9 @@ namespace GameLovers.UiService
 		private readonly IDictionary<int, GameObject> _layers = new Dictionary<int, GameObject>();
 		private readonly IDictionary<Type, UiPresenter> _uiPresenters = new Dictionary<Type, UiPresenter>();
 
+		private Type _loadingSpinnerType;
+		private Transform _uiParent;
+
 		/// <inheritdoc />
 		public IReadOnlyDictionary<Type, UiPresenter> LoadedPresenters => new Dictionary<Type, UiPresenter>(_uiPresenters);
 
@@ -28,8 +31,8 @@ namespace GameLovers.UiService
 		/// <inheritdoc />
 		public IReadOnlyDictionary<int, UiSetConfig> UiSets => new Dictionary<int, UiSetConfig>(_uiSets);
 
-		private Type _loadingSpinnerType;
-		private Transform _uiParent;
+		/// <inheritdoc />
+		public IReadOnlyList<Type> VisiblePresenters => new List<Type>(_visibleUiList);
 
 		public UiService() : this(new UiAssetLoader()) { }
 
@@ -63,6 +66,18 @@ namespace GameLovers.UiService
 			{
 				_ = LoadUiAsync(_loadingSpinnerType);
 			}
+		}
+
+		/// <inheritdoc />
+		public T GetUi<T>() where T : UiPresenter
+		{
+			return _uiPresenters[typeof(T)] as T;
+		}
+
+		/// <inheritdoc />
+		public bool IsVisible<T>() where T : UiPresenter
+		{
+			return _visibleUiList.Contains(typeof(T));
 		}
 
 		/// <inheritdoc />
@@ -217,12 +232,6 @@ namespace GameLovers.UiService
 					UnloadUi(type);
 				}
 			}
-		}
-
-		/// <inheritdoc />
-		public List<Type> GetAllVisibleUi()
-		{
-			return new List<Type>(_visibleUiList);
 		}
 
 		/// <inheritdoc />

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "com.gamelovers.uiservice",
   "displayName": "UiService",
   "author": "Miguel Tomas",
-  "version": "0.8.0",
-  "unity": "2022.4",
+  "version": "0.9.0",
+  "unity": "2022.3",
   "license": "MIT",
   "description": "This package provides a service to help manage an Unity's, game UI.\nIt allows to open, close, load, unload and request any Ui Configured in the game.\nThe package provides a Ui Set that allows to group a set of Ui Presenters to help load, open and close multiple Uis at the same time.\n\nTo help configure the game's UI you need to create a UiConfigs Scriptable object by:\n- Right Click on the Project View > Create > ScriptableObjects > Configs > UiConfigs",
   "dependencies": {


### PR DESCRIPTION
- Added *GetUi<T>* method to the *IUiService*. It requests the *UiPresenter* by directly using generic T
- Added *IsVisible<T>* method to the *IUiService*. It requests the visibility state of *UiPresenter*
- Added IReadOnlyList property *VisiblePresenters* to the *IUiService* to allow external entities to access the list of visible *UiPresenter*

***Changed**:
- Removed *GetAllVisibleUi()* method. Use *IsVisible<T>* method instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 0.9.0

- **New Features**
  - Introduced new methods for enhanced UI management: `GetUi<T>()` for retrieving UI presenters and `IsVisible<T>()` for checking their visibility.
  - Added a `VisiblePresenters` property to access currently visible UI presenters.

- **Bug Fixes**
  - Improved error handling in UI loading and unloading processes.
  - Adjusted methods to provide warnings for UI state conflicts (e.g., attempting to open an already visible UI).

- **Chores**
  - Updated versioning in the package to reflect the new release and adjusted Unity compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->